### PR TITLE
[Ch12ex13] the S-expression processes as encoding/json

### DIFF
--- a/ch12/ex13/sexpr/decode.go
+++ b/ch12/ex13/sexpr/decode.go
@@ -1,0 +1,179 @@
+// Copyright 2017 budougumi0617 All Rights Reserved.
+
+package sexpr
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"text/scanner"
+)
+
+var Interfaces map[string]reflect.Type
+
+// Unmarshal parses S-expression data and populates the variable
+// whose address is in the non-nil pointer out.
+func Unmarshal(data []byte, out interface{}) (err error) {
+	lex := &lexer{scan: scanner.Scanner{Mode: scanner.GoTokens}}
+	lex.scan.Init(bytes.NewReader(data))
+	lex.next() // get the first token
+	defer func() {
+		// NOTE: this is not an example of ideal error handling.
+		if x := recover(); x != nil {
+			err = fmt.Errorf("error at %s: %v", lex.scan.Position, x)
+		}
+	}()
+	read(lex, reflect.ValueOf(out).Elem())
+	return nil
+}
+
+type lexer struct {
+	scan  scanner.Scanner
+	token rune // the current token
+}
+
+func (lex *lexer) next()        { lex.token = lex.scan.Scan() }
+func (lex *lexer) text() string { return lex.scan.TokenText() }
+
+func (lex *lexer) consume(want rune) {
+	if lex.token != want { // NOTE: Not an example of good error handling.
+		panic(fmt.Sprintf("got %q, want %q", lex.text(), want))
+	}
+	lex.next()
+}
+
+// The read function is a decoder for a small subset of well-formed
+// S-expressions.  For brevity of our example, it takes many dubious
+// shortcuts.
+//
+// The parser assumes
+// - that the S-expression input is well-formed; it does no error checking.
+// - that the S-expression input corresponds to the type of the variable.
+// - that all numbers in the input are non-negative decimal integers.
+// - that all keys in ((key value) ...) struct syntax are unquoted symbols.
+// - that the input does not contain dotted lists such as (1 2 . 3).
+// - that the input does not contain Lisp reader macros such 'x and #'x.
+//
+// The reflection logic assumes
+// - that v is always a variable of the appropriate type for the
+//   S-expression value.  For example, v must not be a boolean,
+//   interface, channel, or function, and if v is an array, the input
+//   must have the correct number of elements.
+// - that v in the top-level call to read has the zero value of its
+//   type and doesn't need clearing.
+// - that if v is a numeric variable, it is a signed integer.
+
+func read(lex *lexer, v reflect.Value) {
+	switch lex.token {
+	case scanner.Ident:
+		// The only valid identifiers are "nil", "t", and struct field names.
+		switch lex.text() {
+		case "nil":
+			v.Set(reflect.Zero(v.Type()))
+			lex.next()
+			return
+		case "t":
+			v.SetBool(true)
+			lex.next()
+			return
+		}
+	case scanner.String:
+		s, _ := strconv.Unquote(lex.text()) // NOTE: ignoring errors
+		v.SetString(s)
+		lex.next()
+		return
+	case scanner.Int:
+		i, _ := strconv.Atoi(lex.text()) // NOTE: ignoring errors
+		switch v.Type().Kind() {
+		case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+			v.SetInt(int64(i))
+			lex.next()
+			return
+		case reflect.Float32, reflect.Float64:
+			v.SetFloat(float64(i))
+			lex.next()
+			return
+		}
+	case scanner.Float:
+		f, _ := strconv.ParseFloat(lex.text(), 64) // NOTE: ignoring errors
+		v.SetFloat(float64(f))
+		lex.next()
+		return
+	case '(':
+		lex.next()
+		readList(lex, v)
+		lex.next() // consume ')'
+		return
+	}
+	panic(fmt.Sprintf("unexpected token %q", lex.text()))
+}
+
+func readList(lex *lexer, v reflect.Value) {
+	switch v.Kind() {
+	case reflect.Array: // (item ...)
+		for i := 0; !endList(lex); i++ {
+			read(lex, v.Index(i))
+		}
+
+	case reflect.Slice: // (item ...)
+		for !endList(lex) {
+			item := reflect.New(v.Type().Elem()).Elem()
+			read(lex, item)
+			v.Set(reflect.Append(v, item))
+		}
+
+	case reflect.Struct: // ((name value) ...)
+		for !endList(lex) {
+			lex.consume('(')
+			if lex.token != scanner.Ident {
+				panic(fmt.Sprintf("got token %q, want field name", lex.text()))
+			}
+			name := lex.text()
+			lex.next()
+			read(lex, v.FieldByName(name))
+			lex.consume(')')
+		}
+
+	case reflect.Map: // ((key value) ...)
+		v.Set(reflect.MakeMap(v.Type()))
+		for !endList(lex) {
+			lex.consume('(')
+			key := reflect.New(v.Type().Key()).Elem()
+			read(lex, key)
+			value := reflect.New(v.Type().Elem()).Elem()
+			read(lex, value)
+			v.SetMapIndex(key, value)
+			lex.consume(')')
+		}
+
+	case reflect.Interface: // (name value)
+		name := strings.Trim(lex.text(), `"`)
+		lex.next()
+		typ, ok := Interfaces[name]
+		if !ok {
+			panic(fmt.Sprintf("no concrete type registered for interface %s", name))
+		}
+		val := reflect.New(typ)
+		read(lex, reflect.Indirect(val))
+		v.Set(reflect.Indirect(val))
+
+	default:
+		panic(fmt.Sprintf("cannot decode list into %v", v.Type()))
+	}
+}
+
+func endList(lex *lexer) bool {
+	switch lex.token {
+	case scanner.EOF:
+		panic("end of file")
+	case ')':
+		return true
+	}
+	return false
+}
+
+func init() {
+	Interfaces = make(map[string]reflect.Type)
+}

--- a/ch12/ex13/sexpr/encode.go
+++ b/ch12/ex13/sexpr/encode.go
@@ -52,6 +52,13 @@ func encode(buf *bytes.Buffer, v reflect.Value) error {
 	case reflect.Struct: // ((name value) ...)
 		buf.WriteByte('(')
 		for i := 0; i < v.NumField(); i++ {
+			fieldInfo := v.Type().Field(i)
+			tag := fieldInfo.Tag
+			name := tag.Get("sexpr")
+			if name == "" {
+				name = fieldInfo.Name
+			}
+
 			if i > 0 {
 				buf.WriteByte(' ')
 			}

--- a/ch12/ex13/sexpr/encode.go
+++ b/ch12/ex13/sexpr/encode.go
@@ -1,0 +1,107 @@
+// Copyright 2017 budougumi0617 All Rights Reserved.
+
+package sexpr
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+)
+
+// Marshal encodes a Go value in S-expression form.
+func Marshal(v interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	if err := encode(&buf, reflect.ValueOf(v)); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// encode writes to buf an S-expression representation of v.
+func encode(buf *bytes.Buffer, v reflect.Value) error {
+	switch v.Kind() {
+	case reflect.Invalid:
+		buf.WriteString("nil")
+
+	case reflect.Int, reflect.Int8, reflect.Int16,
+		reflect.Int32, reflect.Int64:
+		fmt.Fprintf(buf, "%d", v.Int())
+
+	case reflect.Uint, reflect.Uint8, reflect.Uint16,
+		reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		fmt.Fprintf(buf, "%d", v.Uint())
+
+	case reflect.String:
+		fmt.Fprintf(buf, "%q", v.String())
+
+	case reflect.Ptr:
+		encode(buf, v.Elem())
+
+	case reflect.Array, reflect.Slice: // (value ...)
+		buf.WriteByte('(')
+		for i := 0; i < v.Len(); i++ {
+			if i > 0 {
+				buf.WriteByte(' ')
+			}
+			if err := encode(buf, v.Index(i)); err != nil {
+				return err
+			}
+		}
+		buf.WriteByte(')')
+
+	case reflect.Struct: // ((name value) ...)
+		buf.WriteByte('(')
+		for i := 0; i < v.NumField(); i++ {
+			if i > 0 {
+				buf.WriteByte(' ')
+			}
+			fmt.Fprintf(buf, "(%s ", v.Type().Field(i).Name)
+			if err := encode(buf, v.Field(i)); err != nil {
+				return err
+			}
+			buf.WriteByte(')')
+		}
+		buf.WriteByte(')')
+
+	case reflect.Map: // ((key value) ...)
+		buf.WriteByte('(')
+		for i, key := range v.MapKeys() {
+			if i > 0 {
+				buf.WriteByte(' ')
+			}
+			buf.WriteByte('(')
+			if err := encode(buf, key); err != nil {
+				return err
+			}
+			buf.WriteByte(' ')
+			if err := encode(buf, v.MapIndex(key)); err != nil {
+				return err
+			}
+			buf.WriteByte(')')
+		}
+		buf.WriteByte(')')
+
+	case reflect.Bool: // t | nil
+		if v.Bool() {
+			buf.WriteByte('t')
+		} else {
+			buf.WriteString("nil")
+		}
+
+	case reflect.Float32, reflect.Float64:
+		fmt.Fprintf(buf, "%g", v.Float())
+
+	case reflect.Complex64, reflect.Complex128:
+		c := v.Complex()
+		fmt.Fprintf(buf, "#C(%g %g)", real(c), imag(c))
+
+	case reflect.Interface:
+		fmt.Fprintf(buf, "(%q ", reflect.Indirect(v).Type())
+		encode(buf, reflect.Indirect(v).Elem())
+		buf.WriteByte(')')
+
+	default: // chan, func
+		return fmt.Errorf("unsupported type: %s", v.Type())
+	}
+	return nil
+}

--- a/ch12/ex13/sexpr/sexpr_test.go
+++ b/ch12/ex13/sexpr/sexpr_test.go
@@ -110,9 +110,9 @@ func TestUnmarshal(t *testing.T) {
 	type Interface interface{}
 	type Record struct {
 		B    bool
-		F32  float32 `sexpr:"f32"`
+		F32  float32 `sexpr:"f_32"`
 		F64  float64
-		C64  complex64 `sexpr:"c64"`
+		C64  complex64 `sexpr:"c_64"`
 		C128 complex128
 		I    Interface `sexpr:"i"`
 	}
@@ -122,11 +122,11 @@ func TestUnmarshal(t *testing.T) {
 		want Record
 	}{
 		{
-			`((B t) (F32 2.5) (F64 0) (I ("sexpr.Interface" 5)))`,
-			Record{false, 2.5, 0, 0, 0, Interface(5)},
+			`((B t) (f_32 2.5) (F64 1.5) (i ("sexpr.Interface" 5)))`,
+			Record{true, 2.5, 1.5, 0, 0, Interface(5)},
 		},
 		{
-			`((B nil) (F32 0) (F64 1.5) (I ("sexpr.Interface" 0)))`,
+			`((B nil) (f_32 0) (F64 1.5) (i ("sexpr.Interface" 0)))`,
 			Record{false, 0, 1.5, 0, 0, Interface(0)},
 		},
 	}

--- a/ch12/ex13/sexpr/sexpr_test.go
+++ b/ch12/ex13/sexpr/sexpr_test.go
@@ -23,9 +23,9 @@ import (
 //
 func Test(t *testing.T) {
 	type Movie struct {
-		Title    string
+		Title    string `sexpr:"title`
 		Subtitle string
-		Year     int
+		Year     int `sexpr:"year"`
 		Actor    map[string]string
 		Oscars   []string
 		Sequel   *string

--- a/ch12/ex13/sexpr/sexpr_test.go
+++ b/ch12/ex13/sexpr/sexpr_test.go
@@ -23,11 +23,12 @@ import (
 //
 func Test(t *testing.T) {
 	type Movie struct {
-		Title, Subtitle string
-		Year            int
-		Actor           map[string]string
-		Oscars          []string
-		Sequel          *string
+		Title    string `sexpr:"title"`
+		Subtitle string
+		Year     int `sexpr:"year"`
+		Actor    map[string]string
+		Oscars   []string
+		Sequel   *string
 	}
 	strangelove := Movie{
 		Title:    "Dr. Strangelove",

--- a/ch12/ex13/sexpr/sexpr_test.go
+++ b/ch12/ex13/sexpr/sexpr_test.go
@@ -1,0 +1,142 @@
+// Copyright 2017 budougumi0617 All Rights Reserved.
+
+// Copyright © 2016 Alan A. A. Donovan & Brian W. Kernighan.
+// License: https://creativecommons.org/licenses/by-nc-sa/4.0/
+
+package sexpr
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// Test verifies that encoding and decoding a complex data value
+// produces an equal result.
+//
+// The test does not make direct assertions about the encoded output
+// because the output depends on map iteration order, which is
+// nondeterministic.  The output of the t.Log statements can be
+// inspected by running the test with the -v flag:
+//
+// 	$ go test -v gopl.io/ch12/sexpr
+//
+func Test(t *testing.T) {
+	type Movie struct {
+		Title, Subtitle string
+		Year            int
+		Actor           map[string]string
+		Oscars          []string
+		Sequel          *string
+	}
+	strangelove := Movie{
+		Title:    "Dr. Strangelove",
+		Subtitle: "How I Learned to Stop Worrying and Love the Bomb",
+		Year:     1964,
+		Actor: map[string]string{
+			"Dr. Strangelove":            "Peter Sellers",
+			"Grp. Capt. Lionel Mandrake": "Peter Sellers",
+			"Pres. Merkin Muffley":       "Peter Sellers",
+			"Gen. Buck Turgidson":        "George C. Scott",
+			"Brig. Gen. Jack D. Ripper":  "Sterling Hayden",
+			`Maj. T.J. "King" Kong`:      "Slim Pickens",
+		},
+		Oscars: []string{
+			"Best Actor (Nomin.)",
+			"Best Adapted Screenplay (Nomin.)",
+			"Best Director (Nomin.)",
+			"Best Picture (Nomin.)",
+		},
+	}
+
+	// Encode it
+	data, err := Marshal(strangelove)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	t.Logf("Marshal() = %s\n", data)
+	fmt.Println(string(data))
+
+	// Decode it
+	var movie Movie
+	if err := Unmarshal(data, &movie); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+	t.Logf("Unmarshal() = %+v\n", movie)
+
+	// Check equality.
+	if !reflect.DeepEqual(movie, strangelove) {
+		t.Fatal("not equal")
+	}
+}
+
+func TestMarshal(t *testing.T) {
+	type Interface interface{}
+	type Record struct {
+		B    bool
+		F32  float32
+		F64  float64
+		C64  complex64
+		C128 complex128
+		I    Interface
+	}
+	tests := []struct {
+		r    Record
+		want string
+	}{
+		{
+			Record{true, 2.5, 0, 1 + 2i, 2 + 3i, Interface(5)},
+			`((B t) (F32 2.5) (F64 0) (C64 #C(1 2)) (C128 #C(2 3)) (I ("sexpr.Interface" 5)))`,
+		},
+		{
+			Record{false, 0, 1.5, 0, 1i, Interface(0)},
+			`((B nil) (F32 0) (F64 1.5) (C64 #C(0 0)) (C128 #C(0 1)) (I ("sexpr.Interface" 0)))`,
+		},
+	}
+	for _, test := range tests {
+		data, err := Marshal(test.r)
+		s := string(data)
+		if err != nil {
+			t.Errorf("Marshal(%s): %s", s, err)
+		}
+		if s != test.want {
+			t.Errorf("Marshal(%#v) got %s, wanted %s", test.r, s, test.want)
+		}
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	type Interface interface{}
+	type Record struct {
+		B    bool
+		F32  float32
+		F64  float64
+		C64  complex64
+		C128 complex128
+		I    Interface
+	}
+	Interfaces["sexpr.Interface"] = reflect.TypeOf(int(0))
+	tests := []struct {
+		s    string
+		want Record
+	}{
+		{
+			`((B t) (F32 2.5) (F64 0) (I ("sexpr.Interface" 5)))`,
+			Record{true, 2.5, 0, 0, 0, Interface(5)},
+		},
+		{
+			`((B nil) (F32 0) (F64 1.5) (I ("sexpr.Interface" 0)))`,
+			Record{false, 0, 1.5, 0, 0, Interface(0)},
+		},
+	}
+	for _, test := range tests {
+		var r Record
+		err := Unmarshal([]byte(test.s), &r)
+		if err != nil {
+			t.Errorf("Unmarshal(%q): %s", test.s, err)
+		}
+		if !reflect.DeepEqual(r, test.want) {
+			t.Errorf("Unmarshal(%q) got %#v, wanted %#v", test.s, r, test.want)
+		}
+	}
+}

--- a/ch12/ex13/sexpr/sexpr_test.go
+++ b/ch12/ex13/sexpr/sexpr_test.go
@@ -23,7 +23,7 @@ import (
 //
 func Test(t *testing.T) {
 	type Movie struct {
-		Title    string `sexpr:"title`
+		Title    string `sexpr:"title"`
 		Subtitle string
 		Year     int `sexpr:"year"`
 		Actor    map[string]string
@@ -76,10 +76,10 @@ func TestMarshal(t *testing.T) {
 	type Record struct {
 		B    bool
 		F32  float32
-		F64  float64
+		F64  float64 `sexpr:"f64"`
 		C64  complex64
 		C128 complex128
-		I    Interface
+		I    Interface `sexpr:"i"`
 	}
 	tests := []struct {
 		r    Record
@@ -87,11 +87,11 @@ func TestMarshal(t *testing.T) {
 	}{
 		{
 			Record{true, 2.5, 0, 1 + 2i, 2 + 3i, Interface(5)},
-			`((B t) (F32 2.5) (F64 0) (C64 #C(1 2)) (C128 #C(2 3)) (I ("sexpr.Interface" 5)))`,
+			`((B t) (F32 2.5) (f64 0) (C64 #C(1 2)) (C128 #C(2 3)) (i ("github.com/budougumi0617/gopl/ch12/ex13/sexpr.Interface" 5)))`,
 		},
 		{
 			Record{false, 0, 1.5, 0, 1i, Interface(0)},
-			`((B nil) (F32 0) (F64 1.5) (C64 #C(0 0)) (C128 #C(0 1)) (I ("sexpr.Interface" 0)))`,
+			`((B nil) (F32 0) (f64 1.5) (C64 #C(0 0)) (C128 #C(0 1)) (i ("github.com/budougumi0617/gopl/ch12/ex13/sexpr.Interface" 0)))`,
 		},
 	}
 	for _, test := range tests {

--- a/ch12/ex13/sexpr/sexpr_test.go
+++ b/ch12/ex13/sexpr/sexpr_test.go
@@ -23,9 +23,9 @@ import (
 //
 func Test(t *testing.T) {
 	type Movie struct {
-		Title    string `sexpr:"title"`
+		Title    string
 		Subtitle string
-		Year     int `sexpr:"year"`
+		Year     int
 		Actor    map[string]string
 		Oscars   []string
 		Sequel   *string
@@ -110,11 +110,11 @@ func TestUnmarshal(t *testing.T) {
 	type Interface interface{}
 	type Record struct {
 		B    bool
-		F32  float32
+		F32  float32 `sexpr:"f32"`
 		F64  float64
-		C64  complex64
+		C64  complex64 `sexpr:"c64"`
 		C128 complex128
-		I    Interface
+		I    Interface `sexpr:"i"`
 	}
 	Interfaces["sexpr.Interface"] = reflect.TypeOf(int(0))
 	tests := []struct {
@@ -123,7 +123,7 @@ func TestUnmarshal(t *testing.T) {
 	}{
 		{
 			`((B t) (F32 2.5) (F64 0) (I ("sexpr.Interface" 5)))`,
-			Record{true, 2.5, 0, 0, 0, Interface(5)},
+			Record{false, 2.5, 0, 0, 0, Interface(5)},
 		},
 		{
 			`((B nil) (F32 0) (F64 1.5) (I ("sexpr.Interface" 0)))`,


### PR DESCRIPTION
# Exercise 12.13
Modify the S-expression encoder(Sec12.4) and decoder(Sec12.6) so that they honor the `sexpr:"..."` field tag in a similar manner to `encoding/json`(Sec4.5)

---
# 練習問題 12.13
S式のエンコーダ(12.4節)とデコーダ(12.6節)を修正して、`encoding/json`(4.5節)に似た方法で`sexpr:"..."`のフィールドタグを処理するようにしなさい。
